### PR TITLE
feat: allow for more flexible initialization

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -23,7 +23,9 @@
 
   jQuery(function ($) {
     $(document)
-      .loom("[mu-widget]", "mu-widget", load, hub.call($, "memory", "stopOnFalse"))
+      .loom("[mu-widget]", "mu-widget", load, {
+        "hub": hub.call($, "memory", "stopOnFalse")
+      })
       .weave()
       .fail(console.error.bind(console));
   });

--- a/widget.js
+++ b/widget.js
@@ -31,9 +31,10 @@
   };
 
   return concat.call(widget,
-    function ($element, ns, hub) {
+    function ($element, ns, opt) {
       var me = this;
       var $ = $element.constructor;
+      var hub = opt.hub;
       var subscriptions = [];
 
       $.event.special._remove = _remove;


### PR DESCRIPTION
To support more flexible widget initialization we now pass `hub` inside an `opt` object.

BREAKING CHANGE: Previous to this the widgets took `hub` as a third constructor argument. With this change that should be wrapped in an object like so: `{ "hub": hub }`.